### PR TITLE
Fix sorting broken by a limit on search for valid locations

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -356,7 +356,7 @@ class StockLocation(models.Model):
                 compatible_locations, quants, products
             )
             _logger.debug("pertinent location domain: %s", location_domain)
-            locations = self.search(location_domain, limit=limit)
+            locations = self.search(location_domain)
             valid_location_ids |= set(locations.ids)
 
         # NOTE: self.ids is ordered as expected, so we want to filter the valid


### PR DESCRIPTION
In this context, "self" are sorted locations. The search returns valid
locations. Later, we filter the locations in "self" by keeping only the
valid locations, but keeping the order of "self.ids".  If we apply a
limit on the intermediate search for valid locations, the order of
"self.ids" may be wrong as the search will return only the first valid
id(s) according to its own order which may be different.