### PR TITLE
[FIX] stock_reception_screen: fix package data auto-complete

### DIFF
--- a/stock_reception_screen/tests/test_reception_screen.py
+++ b/stock_reception_screen/tests/test_reception_screen.py
@@ -114,15 +114,9 @@ class TestReceptionScreen(SavepointCase):
         # Check package data (automatically filled normally)
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "select_packaging")
-        self.assertEqual(
-            self.screen.current_move_line_product_packaging_id, self.product_packaging
-        )
-        self.assertEqual(
-            self.screen.current_move_line_storage_type_id, self.storage_type_pallet
-        )
-        self.assertEqual(
-            self.screen.current_move_line_height, self.product_packaging.height
-        )
+        self.assertEqual(self.screen.product_packaging_id, self.product_packaging)
+        self.assertEqual(self.screen.package_storage_type_id, self.storage_type_pallet)
+        self.assertEqual(self.screen.package_height, self.product_packaging.height)
         # The first 4 qties should be validated, creating a 2nd move to process
         self.assertEqual(len(self.picking.move_lines), 2)
         self.screen.button_save_step()
@@ -149,12 +143,12 @@ class TestReceptionScreen(SavepointCase):
         # Check package data (not automatically filled as no packaging match)
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "select_packaging")
-        self.assertFalse(self.screen.current_move_line_product_packaging_id)
-        self.assertFalse(self.screen.current_move_line_storage_type_id)
-        self.assertFalse(self.screen.current_move_line_height)
+        self.assertFalse(self.screen.product_packaging_id)
+        self.assertFalse(self.screen.package_storage_type_id)
+        self.assertFalse(self.screen.package_height)
         # Set mandatory package data
-        self.screen.current_move_line_storage_type_id = self.storage_type_pallet
-        self.screen.current_move_line_height = 20
+        self.screen.package_storage_type_id = self.storage_type_pallet
+        self.screen.package_height = 20
         # Reception done
         self.screen.button_save_step()
 
@@ -179,8 +173,8 @@ class TestReceptionScreen(SavepointCase):
         )
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "select_packaging")
-        self.screen.current_move_line_storage_type_id = self.storage_type_pallet
-        self.screen.current_move_line_height = 20
+        self.screen.package_storage_type_id = self.storage_type_pallet
+        self.screen.package_height = 20
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "done")
         move_states = self.picking.move_lines.mapped("state")

--- a/stock_reception_screen/views/stock_reception_screen.xml
+++ b/stock_reception_screen/views/stock_reception_screen.xml
@@ -84,10 +84,7 @@
                 <field name="current_move_id" invisible="1" />
                 <field name="current_move_product_id" invisible="1" />
                 <field name="current_move_line_id" invisible="1" />
-                <field
-                    name="current_move_line_storage_type_height_required"
-                    invisible="1"
-                />
+                <field name="package_storage_type_height_required" invisible="1" />
                 <div class="o_screen_data">
                     <div class="o_screen_data_content" name="data">
                         <group attrs="{'invisible': [('current_move_id', '=', False)]}">
@@ -192,10 +189,10 @@
                                         attrs="{'readonly': [('current_step', '!=', 'set_package')]}"
                                     />
                                 </div>
-                                <label for="current_move_line_product_packaging_id" />
+                                <label for="product_packaging_id" />
                                 <div>
                                     <field
-                                        name="current_move_line_product_packaging_id"
+                                        name="product_packaging_id"
                                         class="mr8"
                                         style="width: 15em;"
                                         options="{'no_open': True, 'no_create': True}"
@@ -204,10 +201,10 @@
                     }"
                                     />
                                 </div>
-                                <label for="current_move_line_storage_type_id" />
+                                <label for="package_storage_type_id" />
                                 <div>
                                     <field
-                                        name="current_move_line_storage_type_id"
+                                        name="package_storage_type_id"
                                         class="mr8"
                                         style="width: 15em;"
                                         options="{'no_open': True, 'no_create': True}"
@@ -217,14 +214,14 @@
                                     />
                                 </div>
                                 <label
-                                    for="current_move_line_height"
-                                    attrs="{'invisible': [('current_move_line_storage_type_height_required', '=', False)]}"
+                                    for="package_height"
+                                    attrs="{'invisible': [('package_storage_type_height_required', '=', False)]}"
                                 />
                                 <div
-                                    attrs="{'invisible': [('current_move_line_storage_type_height_required', '=', False)]}"
+                                    attrs="{'invisible': [('package_storage_type_height_required', '=', False)]}"
                                 >
                                     <field
-                                        name="current_move_line_height"
+                                        name="package_height"
                                         class="mr8"
                                         style="width: 15em;"
                                         attrs="{


### PR DESCRIPTION
The package data (product packaging, package storage type and height here) are now handled this way:

1) first these data are auto-completed on the screen to let the user changing them if needed, but they are not directly set on the package (method `_autocomplete_package_data`)
2) once the user confirm the "select_packaging" step, these data will be set on the related package (method `_set_package_data`)

This avoids some problems related to existing constraints on the package, like the height which can be mandatory depending on the storage type.

This PR aims to supersede https://github.com/sebalix/wms/pull/4